### PR TITLE
Fix error caused by unknown grep flag

### DIFF
--- a/hack/aws-academy.sh
+++ b/hack/aws-academy.sh
@@ -175,7 +175,7 @@ function checkIfLoggedIn() {
     #local -r teacher=$?
     #echo "${response}" | grep -q "${AWSACADEMY_INSTRUCTURE_STUDENT_LOGIN_URL}"
     #local -r student=$?
-    echo "${response}" | grep -p 'user authorization required'
+    echo "${response}" | grep -q 'user authorization required'
     local -r status=$?
     if [[ "${status}" -eq "0" ]]; then
         return 1


### PR DESCRIPTION
When running the `aws-academy.sh` an error occurs: `grep: invalid option -- 'p'`.
This pull request replaces the unknown flag `-p` with the flag `-q` which is probably the intended flag. From the man pages: 

```
-q, --quiet, --silent
              Quiet;  do  not  write anything to standard output.  Exit immediately with zero status if any match is found, even if an error was detected.
              Also see the -s or --no-messages option.
```
I think this is the correct flag to use here, as we don't care about the output but just use the exist status in the next code lines. 
I tested it with this flag on Ubuntu 22.04.3 LTS and it works. Maybe also test this on macOS before merging. 